### PR TITLE
fix: remove coroutines debug agent to fix test NoSuchMethodError

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,9 +142,21 @@ tasks {
     test {
         // Remove the coroutines debug agent to avoid NoSuchMethodError caused by
         // version mismatch between the agent and IntelliJ's bundled coroutines.
-        // Must be done at configuration time (not doFirst) for Gradle 9 config cache compatibility.
-        jvmArgumentProviders.removeAll {
-            it.javaClass.name.contains("Coroutines")
+        // The agent is added by IntelliJPlatformArgumentProvider via jvmArgumentProviders.
+        // We wrap providers after evaluation to filter out the -javaagent arg.
+    }
+}
+
+afterEvaluate {
+    tasks.test {
+        val originalProviders = jvmArgumentProviders.toList()
+        jvmArgumentProviders.clear()
+        originalProviders.forEach { provider ->
+            jvmArgumentProviders.add(CommandLineArgumentProvider {
+                provider.asArguments().filter { arg ->
+                    !arg.contains("-javaagent") || !arg.contains("coroutines")
+                }
+            })
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,6 +138,14 @@ tasks {
     publishPlugin {
         dependsOn(patchChangelog)
     }
+
+    test {
+        // Remove the coroutines debug agent to avoid NoSuchMethodError caused by
+        // version mismatch between the agent and IntelliJ's bundled coroutines
+        doFirst {
+            jvmArgs = jvmArgs?.filterNot { it.contains("kotlinx-coroutines") }
+        }
+    }
 }
 
 intellijPlatformTesting {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,9 +141,10 @@ tasks {
 
     test {
         // Remove the coroutines debug agent to avoid NoSuchMethodError caused by
-        // version mismatch between the agent and IntelliJ's bundled coroutines
-        doFirst {
-            allJvmArgs = allJvmArgs.filterNot { it.contains("kotlinx-coroutines") }
+        // version mismatch between the agent and IntelliJ's bundled coroutines.
+        // Must be done at configuration time (not doFirst) for Gradle 9 config cache compatibility.
+        jvmArgumentProviders.removeAll {
+            it.javaClass.name.contains("Coroutines")
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.tasks.PrepareTestTask
 
 plugins {
     id("java") // Java support
@@ -139,25 +140,12 @@ tasks {
         dependsOn(patchChangelog)
     }
 
-    test {
-        // Remove the coroutines debug agent to avoid NoSuchMethodError caused by
-        // version mismatch between the agent and IntelliJ's bundled coroutines.
-        // The agent is added by IntelliJPlatformArgumentProvider via jvmArgumentProviders.
-        // We wrap providers after evaluation to filter out the -javaagent arg.
-    }
-}
-
-afterEvaluate {
-    tasks.test {
-        val originalProviders = jvmArgumentProviders.toList()
-        jvmArgumentProviders.clear()
-        originalProviders.forEach { provider ->
-            jvmArgumentProviders.add(CommandLineArgumentProvider {
-                provider.asArguments().filter { arg ->
-                    !arg.contains("-javaagent") || !arg.contains("coroutines")
-                }
-            })
-        }
+    // Disable the coroutines debug agent to avoid NoSuchMethodError caused by
+    // version mismatch between the agent and IntelliJ's bundled coroutines-core.
+    // IntelliJPlatformArgumentProvider reads this property lazily via orNull,
+    // so clearing it here makes the provider skip the -javaagent arg at execution time.
+    named<PrepareTestTask>("prepareTest") {
+        coroutinesJavaAgentFile.set(null as? org.gradle.api.file.RegularFile)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,10 +143,7 @@ tasks {
         // Remove the coroutines debug agent to avoid NoSuchMethodError caused by
         // version mismatch between the agent and IntelliJ's bundled coroutines
         doFirst {
-            jvmArgs = jvmArgs.orEmpty().filterNot { it.contains("kotlinx-coroutines") }.toMutableList()
-            jvmArgumentProviders.removeAll { provider ->
-                provider.asArguments().any { it.contains("kotlinx-coroutines") }
-            }
+            allJvmArgs = allJvmArgs.filterNot { it.contains("kotlinx-coroutines") }
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,7 +143,7 @@ tasks {
         // Remove the coroutines debug agent to avoid NoSuchMethodError caused by
         // version mismatch between the agent and IntelliJ's bundled coroutines
         doFirst {
-            jvmArgs = jvmArgs?.filterNot { it.contains("kotlinx-coroutines") }
+            jvmArgs = jvmArgs?.filterNot { it.contains("kotlinx-coroutines") }?.toMutableList()
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,10 @@ repositories {
 // Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
 dependencies {
     testImplementation(libs.junit)
-    testImplementation(libs.mockk)
+    testImplementation(libs.mockk) {
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
+    }
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {
@@ -48,6 +51,14 @@ dependencies {
     implementation("com.nulab-inc:backlog4j:2.6.0")
 
     testImplementation("org.opentest4j:opentest4j:1.3.0")
+}
+
+// Exclude external kotlinx-coroutines from the test classpath to avoid version conflicts
+// with IntelliJ Platform's bundled coroutines. External versions (e.g. from MockK) cause
+// NoSuchMethodError in CoroutineDumpState / DebugProbesImpl due to internal API changes.
+configurations.testRuntimeClasspath {
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
 }
 
 // Set the JVM language level used to build the project.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,7 +143,7 @@ tasks {
         // Remove the coroutines debug agent to avoid NoSuchMethodError caused by
         // version mismatch between the agent and IntelliJ's bundled coroutines
         doFirst {
-            jvmArgs = jvmArgs?.filterNot { it.contains("kotlinx-coroutines") }?.toMutableList()
+            jvmArgs = jvmArgs.orEmpty().filterNot { it.contains("kotlinx-coroutines") }.toMutableList()
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,6 +144,9 @@ tasks {
         // version mismatch between the agent and IntelliJ's bundled coroutines
         doFirst {
             jvmArgs = jvmArgs.orEmpty().filterNot { it.contains("kotlinx-coroutines") }.toMutableList()
+            jvmArgumentProviders.removeAll { provider ->
+                provider.asArguments().any { it.contains("kotlinx-coroutines") }
+            }
         }
     }
 }

--- a/src/test/kotlin/com/github/badfalcon/backlog/service/BacklogServiceTest.kt
+++ b/src/test/kotlin/com/github/badfalcon/backlog/service/BacklogServiceTest.kt
@@ -15,6 +15,13 @@ class BacklogServiceTest : BasePlatformTestCase() {
         backlogService = project.getService(BacklogService::class.java)
     }
 
+    override fun tearDown() {
+        backlogService.backlogClient = null
+        backlogService.projectKey = ""
+        backlogService.repoId = 0
+        super.tearDown()
+    }
+
     // --- TopLevelDomain tests ---
 
     fun testTopLevelDomainValues() {

--- a/src/test/kotlin/com/github/badfalcon/backlog/service/GitServiceTest.kt
+++ b/src/test/kotlin/com/github/badfalcon/backlog/service/GitServiceTest.kt
@@ -15,6 +15,11 @@ class GitServiceTest : BasePlatformTestCase() {
         gitService = project.getService(GitService::class.java)
     }
 
+    override fun tearDown() {
+        gitService.repository = null
+        super.tearDown()
+    }
+
     // --- Guard condition tests ---
 
     fun testIsReadyDefaultFalse() {

--- a/src/test/kotlin/com/github/badfalcon/backlog/service/PullRequestServiceTest.kt
+++ b/src/test/kotlin/com/github/badfalcon/backlog/service/PullRequestServiceTest.kt
@@ -17,6 +17,9 @@ class PullRequestServiceTest : BasePlatformTestCase() {
     override fun setUp() {
         super.setUp()
         pullRequestService = project.getService(PullRequestService::class.java)
+        // Reset to real services to prevent state leaking between tests
+        pullRequestService.backlogService = project.getService(BacklogService::class.java)
+        pullRequestService.gitService = project.getService(GitService::class.java)
     }
 
     // --- Guard condition tests (default state: both services not ready) ---


### PR DESCRIPTION
The kotlinx-coroutines debug agent added by IntelliJ's test framework
is incompatible with the coroutines version bundled in IntelliJ 2025.3.4,
causing AgentPremain to fail with NoSuchMethodError on
DebugProbesImpl.getEnableCreationStackTraces.

https://claude.ai/code/session_01Q6FoydqmcceCPwvxZ4h3Sr