### PR TITLE
Add link to original Backlog pull request in PR detail tab

### DIFF
--- a/src/main/kotlin/com/github/badfalcon/backlog/service/BacklogService.kt
+++ b/src/main/kotlin/com/github/badfalcon/backlog/service/BacklogService.kt
@@ -18,6 +18,7 @@ class BacklogService(project: Project) {
         get() = backlogClient != null
     var projectKey: String = ""
     var repoId: Long = 0
+    var repoName: String = ""
 
     enum class TopLevelDomain(val value: String) {
         COM("com"),
@@ -71,6 +72,7 @@ class BacklogService(project: Project) {
         if (isReady) {
             projectKey = ""
             repoId = 0
+            repoName = ""
             projectLoop@ for (proj in backlogClient!!.projects) {
                 val repositories: ResponseList<Repository>?
                 try {
@@ -82,6 +84,7 @@ class BacklogService(project: Project) {
                     if (repo.httpUrl == targetRemoteUrl) {
                         projectKey = proj.projectKey
                         repoId = repo.id
+                        repoName = repo.name
                         break@projectLoop
                     }
                 }
@@ -100,6 +103,15 @@ class BacklogService(project: Project) {
             return pullRequests
         }
         return null
+    }
+
+    fun getPullRequestUrl(project: Project, prNumber: Long): String? {
+        val settings = MyPluginSettingsState.getInstance(project)
+        if (settings.workspaceName.isEmpty() || projectKey.isEmpty() || repoName.isEmpty()) {
+            return null
+        }
+        val tld = settings.topLevelDomain.value
+        return "https://${settings.workspaceName}.backlog.${tld}/git/${projectKey}/${repoName}/pullRequests/${prNumber}"
     }
 
     fun getImageAttachments(pullRequestId: Long, attachments: MutableList<Attachment>): MutableList<AttachmentData> {

--- a/src/main/kotlin/com/github/badfalcon/backlog/service/ToolWindowService.kt
+++ b/src/main/kotlin/com/github/badfalcon/backlog/service/ToolWindowService.kt
@@ -164,8 +164,7 @@ class ToolWindowService(private val project: Project, private val cs: CoroutineS
                 val attachments = withContext(Dispatchers.IO) { pullRequestService.getAttachments(pullRequest) }
                 ApplicationManager.getApplication().invokeLater {
                     try {
-                        val backlogService = project.getService(BacklogService::class.java)
-                        val prUrl = backlogService.getPullRequestUrl(project, pullRequest.number)
+                        val prUrl = pullRequestService.backlogService.getPullRequestUrl(project, pullRequest.number)
                         val tabContent = BacklogPRDetailTab(
                             pullRequest,
                             project.basePath,

--- a/src/main/kotlin/com/github/badfalcon/backlog/service/ToolWindowService.kt
+++ b/src/main/kotlin/com/github/badfalcon/backlog/service/ToolWindowService.kt
@@ -164,6 +164,8 @@ class ToolWindowService(private val project: Project, private val cs: CoroutineS
                 val attachments = withContext(Dispatchers.IO) { pullRequestService.getAttachments(pullRequest) }
                 ApplicationManager.getApplication().invokeLater {
                     try {
+                        val backlogService = project.getService(BacklogService::class.java)
+                        val prUrl = backlogService.getPullRequestUrl(project, pullRequest.number)
                         val tabContent = BacklogPRDetailTab(
                             pullRequest,
                             project.basePath,
@@ -172,7 +174,8 @@ class ToolWindowService(private val project: Project, private val cs: CoroutineS
                             commits,
                             commitListener,
                             pullRequest.attachments,
-                            attachments
+                            attachments,
+                            prUrl
                         )
                         loadingPanel.stopLoading()
                         loadingPanel.add(tabContent, BorderLayout.CENTER)

--- a/src/main/kotlin/com/github/badfalcon/backlog/tabs/BacklogPRDetailTab.kt
+++ b/src/main/kotlin/com/github/badfalcon/backlog/tabs/BacklogPRDetailTab.kt
@@ -32,7 +32,8 @@ class BacklogPRDetailTab(
     commits: MutableList<GitCommit>?,
     commitSelectionListener: CommitSelectionListener,
     attachments: MutableList<Attachment>?,
-    attachmentData: MutableList<AttachmentData>
+    attachmentData: MutableList<AttachmentData>,
+    prUrl: String? = null
 ) : JBPanel<JBPanel<*>>()  {
     private val basePath = Path(basePathStr?:"")
 
@@ -43,6 +44,9 @@ class BacklogPRDetailTab(
         val overviewPanel = panel {
             row("#" + pullRequest.number.toString()) {
                 label(pullRequest.summary)
+                if (prUrl != null) {
+                    browserLink(BacklogBundle.message("prDetail.overview.openInBacklog"), prUrl)
+                }
             }
             row(BacklogBundle.message("prDetail.overview.author")) {
                 label(pullRequest.createdUser.name)

--- a/src/main/resources/messages/BacklogBundle.properties
+++ b/src/main/resources/messages/BacklogBundle.properties
@@ -10,6 +10,7 @@ homeTab.column.author=Author
 homeTab.column.branch=Branch
 homeTab.table.empty=No pull requests found
 prDetail.error.retry=Retry
+prDetail.overview.openInBacklog=Open in Backlog
 prDetail.overview.author=Author
 prDetail.overview.branch=Branch
 prDetail.tab.description=Description

--- a/src/test/kotlin/com/github/badfalcon/backlog/service/BacklogServiceTest.kt
+++ b/src/test/kotlin/com/github/badfalcon/backlog/service/BacklogServiceTest.kt
@@ -21,6 +21,11 @@ class BacklogServiceTest : BasePlatformTestCase() {
         backlogService.projectKey = ""
         backlogService.repoId = 0
         backlogService.repoName = ""
+        val settings = MyPluginSettingsState.getInstance(project)
+        settings.workspaceName = ""
+        settings.apiKey = ""
+        settings.projectName = ""
+        settings.topLevelDomain = BacklogService.TopLevelDomain.COM
         super.tearDown()
     }
 

--- a/src/test/kotlin/com/github/badfalcon/backlog/service/BacklogServiceTest.kt
+++ b/src/test/kotlin/com/github/badfalcon/backlog/service/BacklogServiceTest.kt
@@ -1,5 +1,6 @@
 package com.github.badfalcon.backlog.service
 
+import com.github.badfalcon.backlog.config.MyPluginSettingsState
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.nulabinc.backlog4j.*
 import com.nulabinc.backlog4j.Project as BacklogProject
@@ -19,6 +20,7 @@ class BacklogServiceTest : BasePlatformTestCase() {
         backlogService.backlogClient = null
         backlogService.projectKey = ""
         backlogService.repoId = 0
+        backlogService.repoName = ""
         super.tearDown()
     }
 
@@ -82,6 +84,7 @@ class BacklogServiceTest : BasePlatformTestCase() {
         val mockRepo = mockk<Repository>()
         every { mockRepo.httpUrl } returns targetUrl
         every { mockRepo.id } returns 42L
+        every { mockRepo.name } returns "repo"
 
         val mockProject = mockk<BacklogProject>()
         every { mockProject.projectKey } returns "PROJ"
@@ -104,6 +107,7 @@ class BacklogServiceTest : BasePlatformTestCase() {
         assertNotNull(result)
         assertEquals("PROJ", backlogService.projectKey)
         assertEquals(42L, backlogService.repoId)
+        assertEquals("repo", backlogService.repoName)
     }
 
     fun testGetPullRequestsNoMatchingRepo() {
@@ -127,6 +131,54 @@ class BacklogServiceTest : BasePlatformTestCase() {
 
         assertNull(result)
     }
+
+    // --- getPullRequestUrl tests ---
+
+    fun testGetPullRequestUrlSuccess() {
+        val settings = MyPluginSettingsState.getInstance(project)
+        settings.workspaceName = "myworkspace"
+        settings.topLevelDomain = BacklogService.TopLevelDomain.COM
+
+        backlogService.projectKey = "PROJ"
+        backlogService.repoName = "repo"
+
+        val url = backlogService.getPullRequestUrl(project, 123L)
+        assertEquals("https://myworkspace.backlog.com/git/PROJ/repo/pullRequests/123", url)
+    }
+
+    fun testGetPullRequestUrlWithJpDomain() {
+        val settings = MyPluginSettingsState.getInstance(project)
+        settings.workspaceName = "myworkspace"
+        settings.topLevelDomain = BacklogService.TopLevelDomain.JP
+
+        backlogService.projectKey = "PROJ"
+        backlogService.repoName = "repo"
+
+        val url = backlogService.getPullRequestUrl(project, 456L)
+        assertEquals("https://myworkspace.backlog.jp/git/PROJ/repo/pullRequests/456", url)
+    }
+
+    fun testGetPullRequestUrlReturnsNullWhenMissingData() {
+        val settings = MyPluginSettingsState.getInstance(project)
+        settings.workspaceName = ""
+
+        backlogService.projectKey = "PROJ"
+        backlogService.repoName = "repo"
+
+        assertNull(backlogService.getPullRequestUrl(project, 123L))
+    }
+
+    fun testGetPullRequestUrlReturnsNullWhenMissingRepoName() {
+        val settings = MyPluginSettingsState.getInstance(project)
+        settings.workspaceName = "myworkspace"
+
+        backlogService.projectKey = "PROJ"
+        backlogService.repoName = ""
+
+        assertNull(backlogService.getPullRequestUrl(project, 123L))
+    }
+
+    // --- getImageAttachments tests ---
 
     fun testGetImageAttachmentsWhenReady() {
         val mockAttachmentData = mockk<AttachmentData>()

--- a/src/test/kotlin/com/github/badfalcon/backlog/service/BacklogServiceTest.kt
+++ b/src/test/kotlin/com/github/badfalcon/backlog/service/BacklogServiceTest.kt
@@ -183,6 +183,16 @@ class BacklogServiceTest : BasePlatformTestCase() {
         assertNull(backlogService.getPullRequestUrl(project, 123L))
     }
 
+    fun testGetPullRequestUrlReturnsNullWhenMissingProjectKey() {
+        val settings = MyPluginSettingsState.getInstance(project)
+        settings.workspaceName = "myworkspace"
+
+        backlogService.projectKey = ""
+        backlogService.repoName = "repo"
+
+        assertNull(backlogService.getPullRequestUrl(project, 123L))
+    }
+
     // --- getImageAttachments tests ---
 
     fun testGetImageAttachmentsWhenReady() {

--- a/src/test/kotlin/com/github/badfalcon/backlog/service/BacklogServiceTest.kt
+++ b/src/test/kotlin/com/github/badfalcon/backlog/service/BacklogServiceTest.kt
@@ -163,7 +163,7 @@ class BacklogServiceTest : BasePlatformTestCase() {
         assertEquals("https://myworkspace.backlog.jp/git/PROJ/repo/pullRequests/456", url)
     }
 
-    fun testGetPullRequestUrlReturnsNullWhenMissingData() {
+    fun testGetPullRequestUrlReturnsNullWhenMissingWorkspaceName() {
         val settings = MyPluginSettingsState.getInstance(project)
         settings.workspaceName = ""
 


### PR DESCRIPTION
Users can now click "Open in Backlog" to navigate to the original PR on the
Backlog web UI directly from the PR detail view in the IDE.

https://claude.ai/code/session_0161aMAs6mwAQyje6DvhcEY2