### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-16
+
+### Added
+
+- PRコメントの表示・投稿機能を追加
+- PRステータス変更機能と確認ダイアログを追加
+- PR詳細タブにBacklog元PRへのリンクを追加
+- Backlog記法のサポートを追加（引用、コードブロック、太字、斜体、打ち消し線、リンク、色、テーブル、サムネイル）
+- PR説明文中のURLを自動リンク化
+
+### Changed
+
+- pluginSinceBuild を 251（IntelliJ 2025.1+）に引き上げ
+- 依存関係・プラグインの更新（Kotlin 2.2.20、GitHub Actions等）
+- UI/レイアウトの改善
+
 ## [0.2.0] - 2026-03-29
 
 ### Changed
@@ -19,7 +35,8 @@
 
 - Initial scaffold created from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)
 
-[Unreleased]: https://github.com/badfalcon/backlog/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/badfalcon/backlog/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/badfalcon/backlog/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/badfalcon/backlog/compare/v0.1.5...v0.2.0
 [0.1.5]: https://github.com/badfalcon/backlog/compare/v0.1.2...v0.1.5
 [0.1.2]: https://github.com/badfalcon/backlog/commits/v0.1.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.badfalcon.backlog
 pluginName = backlog
 pluginRepositoryUrl = https://github.com/badfalcon/backlog
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.0
+pluginVersion = 0.3.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251


### PR DESCRIPTION
## Summary

- pluginVersion を 0.2.0 → 0.3.0 に更新
- CHANGELOG.md に v0.3.0 の変更内容を追加
  - PRコメント表示・投稿、ステータス変更機能
  - Backlog記法サポート（引用、コード、太字等）
  - PR詳細タブにBacklog元PRリンク追加
  - pluginSinceBuild 251 への引き上げ

## リリース手順

1. この PR をマージ
2. Build ワークフローが draft release を作成
3. GitHub Releases で draft を確認・publish
4. Release ワークフローが JetBrains Marketplace にパブリッシュ

🤖 Generated with [Claude Code](https://claude.com/claude-code)