### PR TITLE
fix: avoid internal API usage flagged by Plugin Verifier

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.PrepareTestTask
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 
 plugins {
     id("java") // Java support
@@ -65,6 +66,12 @@ configurations.testRuntimeClasspath {
 // Set the JVM language level used to build the project.
 kotlin {
     jvmToolchain(17)
+    compilerOptions {
+        // Generate real JVM default interface methods instead of synthetic compatibility
+        // bridges. Without this, implementing IntelliJ interfaces (e.g. ToolWindowFactory)
+        // emits bridge methods that the Plugin Verifier flags as @ApiStatus.Internal usage.
+        jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
+    }
 }
 
 // Configure IntelliJ Platform Gradle Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html


### PR DESCRIPTION
## 概要
`verifyPlugin`（IntelliJ Plugin Verifier）が `INTERNAL_API_USAGES` で失敗していた問題を修正します。

## 原因
`BacklogToolWindowFactory` のコンパイル結果に、ソースに書いていない合成ブリッジメソッドが生成されていました:

```
public Icon getIcon()               → invokespecial ToolWindowFactory.getIcon
public ToolWindowAnchor getAnchor() → invokespecial ToolWindowFactory.getAnchor
public Object manage(...)           → invokespecial ToolWindowFactory.manage
```

これは Kotlin が `ToolWindowFactory`（IDE側インターフェース）の default メソッドに対して生成する**互換ブリッジ**です。プラグイン自身はこれらの内部APIを一切使っていませんが、IDE 251+ でこれらのメソッドが `@ApiStatus.Internal` 指定されたため、verifier が「内部API使用」として検知し失敗していました（コード未変更でもプラットフォーム側の注釈追加で突然失敗するパターン）。

## 修正
Kotlin に `jvmDefault = NO_COMPATIBILITY` を設定し、本物の JVM default メソッドを使わせて互換ブリッジを生成させないようにします。実装クラスから空のブリッジが消え、内部API使用の検知元がなくなります。

このプラグインは最終成果物（外部からABI参照されない）で、対象JVMは17のため、互換ブリッジを落としても動作は変わりません。

## 検証（ローカル、recommended IDE 5種: 2025.1〜2026.2 EAP）
| 項目 | 修正前 | 修正後 |
|---|---|---|
| `verifyPlugin` | ❌ FAILED (INTERNAL_API_USAGES) | ✅ BUILD SUCCESSFUL |
| 内部API使用 | 6件 | 0件 |
| 合成ブリッジ (bytecode) | あり | 消滅（実メソッド2つのみ） |
| `compileKotlin` / `test` | — | ✅ 通過（回帰なし・警告なし） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)